### PR TITLE
Fix idempotent behavior in task "block later installations of snapd"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
   ansible.builtin.set_fact:
     snapd_services: "{{ snapd_defaults_services | union(snapd_services) | unique }}"
     snapd_files: "{{ snapd_defaults_files | union(snapd_files) | unique }}"
-    snapd_block_packages: "{{ snapd_defaults_block_packages | union(snapd_block_packages) | unique }}"
+    snapd_block_packages: "{{ snapd_defaults_block_packages | union(snapd_block_packages) | unique | sort }}"
 
 - name: remove snap packages
   when:


### PR DESCRIPTION
Unique filter creates list with items are returned in arbitrary order (which leads to changes in subsequent tasks - idempotent behavior issue). Fix this by using sort filter at the end.